### PR TITLE
Fix for: configmap "github-value-config" not found

### DIFF
--- a/scripts/manage-gvm-chart.sh
+++ b/scripts/manage-gvm-chart.sh
@@ -224,7 +224,7 @@ echo "Creating ConfigMap with application configuration..."
 kubectl create configmap github-value-config \
   --from-literal=PORT="$APP_PORT" \
   --from-literal=BASE_URL="$BASE_URL" \
-  --from-literal=GITHUB_APP_ID="$GITHUB_APP_ID" \  
+  --from-literal=GITHUB_APP_ID="$GITHUB_APP_ID" \
   --namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
 
 # Show summary of created resources

--- a/scripts/manage-gvm-chart.sh
+++ b/scripts/manage-gvm-chart.sh
@@ -224,7 +224,7 @@ echo "Creating ConfigMap with application configuration..."
 kubectl create configmap github-value-config \
   --from-literal=PORT="$APP_PORT" \
   --from-literal=BASE_URL="$BASE_URL" \
-  --from-literal=GITHUB_APP_ID="$GITHUB_APP_ID" \   # --from-literal=NODE_HEAP_SIZE="8120" # Uncomment if needed, 4GB is the currrent default
+  --from-literal=GITHUB_APP_ID="$GITHUB_APP_ID" \  
   --namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
 
 # Show summary of created resources


### PR DESCRIPTION
This pull request includes a minor cleanup in the `scripts/manage-gvm-chart.sh` script to fix "Error: configmap "github-value-config" not found"

![image](https://github.com/user-attachments/assets/14bdebcd-dfb4-482a-b9ce-ca93d1bfc5a2)
